### PR TITLE
Add base time option

### DIFF
--- a/source/one_password/one_password.go
+++ b/source/one_password/one_password.go
@@ -85,7 +85,7 @@ func New(apiToken secret.String, opts ...Option) hatchery.Source {
 		now := timestamp.FromCtx(ctx)
 
 		logger := logging.FromCtx(ctx).With("source", "one_password")
-		logger.Info("New source (1Password)", "config", x)
+		logger.Info("New source (1Password)", "config", x, "base_time", now)
 		ctx = logging.InjectCtx(ctx, logger)
 
 		for seq := 0; x.MaxPages == 0 || seq < x.MaxPages; seq++ {


### PR DESCRIPTION
This pull request introduces several enhancements and bug fixes to the `hatchery` package, focusing on adding timestamp functionality, improving logging, and modifying configurations for the Slack source. The most important changes include adding a base time flag, updating log messages to include the base time, and modifying the limit configuration for Slack API requests.

Enhancements to timestamp functionality:

* [`cli.go`](diffhunk://#diff-8d9ca23280f24fe6444d03ae46e7a15dd152170f32f57f978dfbdfd3cfe8ff55R5-R9): Added a `base-time` flag to the CLI for specifying a base time, with the default being the current time. This flag is injected into the context if provided. [[1]](diffhunk://#diff-8d9ca23280f24fe6444d03ae46e7a15dd152170f32f57f978dfbdfd3cfe8ff55R5-R9) [[2]](diffhunk://#diff-8d9ca23280f24fe6444d03ae46e7a15dd152170f32f57f978dfbdfd3cfe8ff55R19) [[3]](diffhunk://#diff-8d9ca23280f24fe6444d03ae46e7a15dd152170f32f57f978dfbdfd3cfe8ff55R52-R60) [[4]](diffhunk://#diff-8d9ca23280f24fe6444d03ae46e7a15dd152170f32f57f978dfbdfd3cfe8ff55R113-R116)

Improvements to logging:

* [`source/one_password/one_password.go`](diffhunk://#diff-d8477cbb5d97402d53b6020db345042c72d0f93a613e3fa7f68d264c37116e70L88-R88): Updated the log message in the `New` function to include the `base_time` value.
* [`source/slack/slack.go`](diffhunk://#diff-8fb52efb85a14aac6da2eaf6a854f65f8c4ef64138498b205b3cc8169daffab8L59-R59): Updated the log message in the `New` function to include the `base_time` value.

Modifications to Slack source configuration:

* [`source/slack/slack.go`](diffhunk://#diff-8fb52efb85a14aac6da2eaf6a854f65f8c4ef64138498b205b3cc8169daffab8L46-R46): Increased the default `Limit` value from 100 to 1000 and updated the `WithLimit` function to handle zero or negative values by excluding the `limit` parameter from the request. [[1]](diffhunk://#diff-8fb52efb85a14aac6da2eaf6a854f65f8c4ef64138498b205b3cc8169daffab8L46-R46) [[2]](diffhunk://#diff-8fb52efb85a14aac6da2eaf6a854f65f8c4ef64138498b205b3cc8169daffab8L86-R86) [[3]](diffhunk://#diff-8fb52efb85a14aac6da2eaf6a854f65f8c4ef64138498b205b3cc8169daffab8R117-R123)